### PR TITLE
Render $hydro_symbol_prompt even on error

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -42,7 +42,7 @@ function _hydro_prompt --on-event fish_prompt
 
     for code in $last_status
         if test $code -ne 0
-            set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
+            set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]$hydro_symbol_prompt
             break
         end
     end
@@ -110,4 +110,3 @@ set --query hydro_symbol_prompt || set --global hydro_symbol_prompt ❱
 set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑
 set --query hydro_symbol_git_behind || set --global hydro_symbol_git_behind ↓
-


### PR DESCRIPTION
First of all, thank you for a great plugin, IMO this is the best fish prompt out there!

I use `hydro_symbol_prompt = "\n❱"`, so long dir paths and branch names look pretty and separate from an actual command. But if a command fails, the new line isn't there. This PR fixes it.

Before:
<img width="479" alt="Screenshot 2021-04-08 at 12 34 08" src="https://user-images.githubusercontent.com/480160/114012583-cbe80a00-9866-11eb-8c3f-206f2e02d4e2.png">

After:
<img width="458" alt="Screenshot 2021-04-08 at 12 34 28" src="https://user-images.githubusercontent.com/480160/114012604-d3a7ae80-9866-11eb-9dcb-5ba720e2cb73.png">
