### PR TITLE
Allow prompt symbol to be shown and customized on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,30 +94,33 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Symbols
 
-| Variable                  | Type   | Description                     | Default |
-| ------------------------- | ------ | ------------------------------- | ------- |
-| `hydro_symbol_prompt`     | string | Prompt symbol.                  | ❱       |
-| `hydro_symbol_git_dirty`  | string | Dirty repository symbol.        | •       |
-| `hydro_symbol_git_ahead`  | string | Ahead of your upstream symbol.  | ↑       |
-| `hydro_symbol_git_behind` | string | Behind of your upstream symbol. | ↓       |
+| Variable                    | Type   | Description                                    | Default |
+| --------------------------- | ------ | ---------------------------------------------- | ------- |
+| `hydro_symbol_prompt`       | string | Prompt symbol.                                 | ❱       |
+| `hydro_symbol_prompt_error` | string | Prompt symbol when an error occurs (if shown). | ❱       |
+| `hydro_symbol_git_dirty`    | string | Dirty repository symbol.                       | •       |
+| `hydro_symbol_git_ahead`    | string | Ahead of your upstream symbol.                 | ↑       |
+| `hydro_symbol_git_behind`   | string | Behind of your upstream symbol.                | ↓       |
 
 ### Colors
 
 > Any argument accepted by [`set_color`](https://fishshell.com/docs/current/cmds/set_color.html).
 
-| Variable               | Type  | Description                    | Default              |
-| ---------------------- | ----- | ------------------------------ | -------------------- |
-| `hydro_color_pwd`      | color | Color of the pwd segment.      | `$fish_color_normal` |
-| `hydro_color_git`      | color | Color of the git segment.      | `$fish_color_normal` |
-| `hydro_color_error`    | color | Color of the error segment.    | `$fish_color_error`  |
-| `hydro_color_prompt`   | color | Color of the prompt symbol.    | `$fish_color_normal` |
-| `hydro_color_duration` | color | Color of the duration section. | `$fish_color_normal` |
+| Variable                     | Type  | Description                                     | Default              |
+| ---------------------------- | ----- | ----------------------------------------------- | -------------------- |
+| `hydro_color_pwd`            | color | Color of the pwd segment.                       | `$fish_color_normal` |
+| `hydro_color_git`            | color | Color of the git segment.                       | `$fish_color_normal` |
+| `hydro_color_error`          | color | Color of the error segment.                     | `$fish_color_error`  |
+| `hydro_color_prompt`         | color | Color of the prompt symbol.                     | `$fish_color_normal` |
+| `hydro_color_prompt_error`   | color | Color of the prompt symbol on error (if shown). | `$fish_color_error`  |
+| `hydro_color_duration`       | color | Color of the duration section.                  | `$fish_color_normal` |
 
 ### Flags
 
-| Variable      | Type    | Description                         | Default |
-| ------------- | ------- | ----------------------------------- | ------- |
-| `hydro_fetch` | boolean | Fetch git remote in the background. | `false` |
+| Variable                            | Type    | Description                                                        | Default |
+| ----------------------------------- | ------- | ------------------------------------------------------------------ | ------- |
+| `hydro_fetch`                       | boolean | Fetch git remote in the background.                                | `false` |
+| `hydro_show_prompt_symbol_on_error` | boolean | Show the prompt symbol after the error segment if an error occurs. | `false` |
 
 ## License
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -43,6 +43,7 @@ function _hydro_prompt --on-event fish_prompt
     for code in $last_status
         if test $code -ne 0
             set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
+            test "$hydro_show_prompt_symbol_on_error" = true && set --append _hydro_prompt "$_hydro_color_prompt_error$hydro_symbol_prompt_error"
             break
         end
     end
@@ -99,14 +100,16 @@ function _hydro_uninstall --on-event hydro_uninstall
     functions --erase (functions --all | string match --entire --regex "^_?hydro_")
 end
 
-for color in hydro_color_{pwd,git,error,prompt,duration}
+for color in hydro_color_{pwd,git,error,prompt,prompt_error,duration}
     function $color --on-variable $color --inherit-variable color
         set --query $color && set --global _$color (set_color $$color)
     end && $color
 end
 
 set --query hydro_color_error || set --global hydro_color_error $fish_color_error
+set --query hydro_color_prompt_error || set --global hydro_color_prompt_error $fish_color_error
 set --query hydro_symbol_prompt || set --global hydro_symbol_prompt ❱
+set --query hydro_symbol_prompt_error || set --global hydro_symbol_prompt_error ❱
 set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑
 set --query hydro_symbol_git_behind || set --global hydro_symbol_git_behind ↓


### PR DESCRIPTION
This adds three new variables that allow to show and customize the prompt symbol when an error occurs:

| Variable | Type | Description | Default |
| --- | --- | --- | ------- |
| `hydro_show_prompt_symbol_on_error` | boolean | Show the prompt symbol after the error segment if an error occurs. | `false` |
| `hydro_symbol_prompt_error` | string | Prompt symbol when an error occurs (if shown). | ❱ |
| `hydro_color_prompt_error`   | color | Color of the prompt symbol on error (if shown). | `$fish_color_error` |

This covers the use case of #11 but makes it configurable (instead of always showing the prompt).