### PR TITLE
Use pipe instead of 'latin letter dental click'

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -42,7 +42,7 @@ function _hydro_prompt --on-event fish_prompt
 
     for code in $last_status
         if test $code -ne 0
-            set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
+            set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2m|\x1b[22m" $last_status)]
             break
         end
     end


### PR DESCRIPTION
The pipestatus display is currently using utf-8's 'latin letter dental click' instead of pipe: https://www.fileformat.info/info/unicode/char/01c0/index.htm

If changing this always is a problem, a configurable variable would be super for displays which don't handle utf-8 well.