### PR TITLE
Add a two line prompt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Flags
 
-| Variable      | Type    | Description                         | Default |
-| ------------- | ------- | ----------------------------------- | ------- |
-| `hydro_fetch` | boolean | Fetch git remote in the background. | `false` |
+| Variable                | Type    | Description                                | Default |
+| ----------------------- | ------- | ------------------------------------------ | ------- |
+| `hydro_fetch`           | boolean | Fetch git remote in the background.        | `false` |
+| `hydro_two_line_prompt` | boolean | Display prompt character on a second line. | `false` |
 
 ## License
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -38,7 +38,12 @@ end
 function _hydro_prompt --on-event fish_prompt
     set --local last_status $pipestatus
     set --query _hydro_pwd || _hydro_pwd
-    set --global _hydro_prompt "$_hydro_color_prompt$hydro_symbol_prompt"
+    
+    if $hydro_two_line_prompt
+     set --global _hydro_prompt \n"$_hydro_color_prompt$hydro_symbol_prompt"
+    else 
+     set --global _hydro_prompt "$_hydro_color_prompt$hydro_symbol_prompt"
+    end
 
     for code in $last_status
         if test $code -ne 0
@@ -108,6 +113,7 @@ for color in hydro_color_{pwd,git,error,prompt,duration}
 end
 
 set --query hydro_color_error || set --global hydro_color_error $fish_color_error
+set --query hydro_two_line_prompt || set --global hydro_two_line_prompt false
 set --query hydro_symbol_prompt || set --global hydro_symbol_prompt ❱
 set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -37,19 +37,20 @@ end
 
 function _hydro_prompt --on-event fish_prompt
     set --local last_status $pipestatus
+    set --local _error_display_fragment
     set --query _hydro_pwd || _hydro_pwd
-    
-    if $hydro_two_line_prompt
-     set --global _hydro_prompt \n"$_hydro_color_prompt$hydro_symbol_prompt"
-    else 
-     set --global _hydro_prompt "$_hydro_color_prompt$hydro_symbol_prompt"
-    end
 
     for code in $last_status
         if test $code -ne 0
-            set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
+            set _error_display_fragment "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
             break
         end
+    end
+
+    if $hydro_two_line_prompt
+     set --global _hydro_prompt "$_error_display_fragment"\n"$_hydro_color_prompt$hydro_symbol_prompt"
+    else 
+     set --global _hydro_prompt "$_error_display_fragment $_hydro_color_prompt$hydro_symbol_prompt"
     end
 
     command kill $_hydro_last_pid 2>/dev/null


### PR DESCRIPTION
Loving this prompt as I explore fish, but I work in super long directories 
so wanted a second line.

This adds a boolean flag `hydro_two_line_prompt`. If that is true, inserts a
newline before the prompt character.
