### PR TITLE
Multiline prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Modify variables using `set --universal` from the command line or `set --global`
 | `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false` |
 | `hydro_multiline` | boolean | Display prompt character on a separate line. | `false` |
 
+### Misc
+
+| Variable                     | Type    | Description                                              | Default |
+| ---------------------------- | ------- | -------------------------------------------------------- | ------- |
+| `fish_prompt_pwd_dir_length` | numeric | The number of characters to display when path shortening | 1       |
+
+
 ## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Flags
 
-| Variable      | Type    | Description                         | Default |
-| ------------- | ------- | ----------------------------------- | ------- |
-| `hydro_fetch` | boolean | Fetch git remote in the background. | `false` |
+| Variable          | Type    | Description                                  | Default |
+| ----------------- | ------- | -------------------------------------------- | ------- |
+| `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false` |
+| `hydro_multiline` | boolean | Display prompt character on a separate line. | `false` |
 
 ## License
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -38,11 +38,11 @@ end
 function _hydro_prompt --on-event fish_prompt
     set --local last_status $pipestatus
     set --query _hydro_pwd || _hydro_pwd
-    set --global _hydro_prompt "$_hydro_color_prompt$hydro_symbol_prompt"
+    set --global _hydro_prompt "$_hydro_color_prompt$_hydro_newline$hydro_symbol_prompt"
 
     for code in $last_status
         if test $code -ne 0
-            set _hydro_prompt "$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
+            set _hydro_prompt "$_hydro_newline$_hydro_color_error"[(string join "\x1b[2mǀ\x1b[22m" $last_status)]
             break
         end
     end
@@ -105,8 +105,17 @@ for color in hydro_color_{pwd,git,error,prompt,duration}
     end && $color
 end
 
+function hydro_multiline --on-variable hydro_multiline
+    if test "$hydro_multiline" = true
+        set --global _hydro_newline "\n"
+    else
+        set --global _hydro_newline ""
+    end
+end && hydro_multiline
+
 set --query hydro_color_error || set --global hydro_color_error $fish_color_error
 set --query hydro_symbol_prompt || set --global hydro_symbol_prompt ❱
 set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑
 set --query hydro_symbol_git_behind || set --global hydro_symbol_git_behind ↓
+set --query hydro_multiline || set --global hydro_multiline false

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -47,7 +47,7 @@ end
 function _hydro_prompt --on-event fish_prompt
     set --local last_status $pipestatus
     set --query _hydro_pwd || _hydro_pwd
-    set --global _hydro_prompt "$_hydro_color_prompt$_hydro_newline$hydro_symbol_prompt"
+    set --global _hydro_prompt "$_hydro_newline$_hydro_color_prompt$hydro_symbol_prompt"
 
     for code in $last_status
         if test $code -ne 0

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -7,16 +7,25 @@ function $_hydro_git --on-variable $_hydro_git
 end
 
 function _hydro_pwd --on-variable PWD
-    set --local root (command git rev-parse --show-toplevel 2>/dev/null |
-        string replace --all --regex -- "^.*/" "")
-    set --global _hydro_pwd (
-        string replace --ignore-case -- ~ \~ $PWD |
-        string replace -- "/$root/" /:/ |
-        string replace --regex --all -- "(\.?[^/]{1})[^/]*/" \$1/ |
-        string replace -- : "$root" |
-        string replace --regex -- '([^/]+)$' "\x1b[1m\$1\x1b[22m" |
-        string replace --regex --all -- '(?!^/$)/' "\x1b[2m/\x1b[22m"
-    )
+    set --query fish_prompt_pwd_dir_length || set --local fish_prompt_pwd_dir_length 1
+    if test "$fish_prompt_pwd_dir_length" -le 0 || test "$hydro_multiline" = true
+        set --global _hydro_pwd (
+            string replace --ignore-case -- ~ \~ $PWD |
+            string replace --regex -- '([^/]+)$' "\x1b[1m\$1\x1b[22m" |
+            string replace --regex --all -- '(?!^/$)/' "\x1b[2m/\x1b[22m"
+        )
+    else
+        set --local root (command git rev-parse --show-toplevel 2>/dev/null |
+            string replace --all --regex -- "^.*/" "")
+        set --global _hydro_pwd (
+            string replace --ignore-case -- ~ \~ $PWD |
+            string replace -- "/$root/" /:/ |
+            string replace --regex --all -- "(\.?[^/]{"$fish_prompt_pwd_dir_length"})[^/]*/" \$1/ |
+            string replace -- : "$root" |
+            string replace --regex -- '([^/]+)$' "\x1b[1m\$1\x1b[22m" |
+            string replace --regex --all -- '(?!^/$)/' "\x1b[2m/\x1b[22m"
+        )
+    end
     test "$root" != "$_hydro_git_root" &&
         set --global _hydro_git_root $root && set $_hydro_git
 end


### PR DESCRIPTION
This is an alternative implementation of https://github.com/jorgebucaran/hydro/pull/21 that builds on the idea with a couple extras:

- Multiline prompts display the full path because there's room
- Single line prompts allow customization of path length via the `fish_prompt_pwd_dir_length` variable (similar to the [prompt_pwd](https://fishshell.com/docs/current/cmds/prompt_pwd.html) implementation)