### PR TITLE
Add support for weird characters in working dir

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -11,7 +11,7 @@ function _hydro_pwd --on-variable PWD
     set --local pwd (
         string replace --ignore-case -- ~ \~ $PWD | string escape
     )
-    if test "$fish_prompt_pwd_dir_length" -le 0 || test "$hydro_multiline" = true
+    if test "$fish_prompt_pwd_dir_length" -gt 0 && test "$hydro_multiline" != true
     else
         set --local toplevel (
             command git rev-parse --show-toplevel 2>/dev/null |
@@ -22,9 +22,7 @@ function _hydro_pwd --on-variable PWD
             echo -n $pwd |
             string replace -- "/$toplevel/" /:/ |
             string replace --regex --all -- "(\.?[^/]{"$fish_prompt_pwd_dir_length"})[^/]*/" \$1/ |
-            string replace -- : "$toplevel" |
-            string replace --regex -- '([^/]+)$' "\x1b[1m\$1\x1b[22m" |
-            string replace --regex --all -- '(?!^/$)/' "\x1b[2m/\x1b[22m"
+            string replace -- : "$toplevel" 
         )
     end
     set --global _hydro_pwd (


### PR DESCRIPTION
The "big" change is adding `string escape` on the working directory (it's then passed through `string unescape` in `fish_prompt`).

While I was at it, I also made the style a bit more consistent and removed a little duplication.

This shoud fix #27  (ie. it does in my tests, but it's difficult to exclude there may be more strangeness).

There is still a potential issue if one is in a git directory and the path to the git "root" contains a colon (yes, quite the astral conjunciton :smile: ). This is because a colon as a magic value in `string replace -- "/$toplevel/" /:/` to preserve the full unshortened (is it a word?) directory name of the git root... I guess it should be fixed by splitting the `PWD` in three portions (before the git root, git root segment, after the git root) and shortening parts 1 and 3 separately.
