### PR TITLE
Fix multiline prompt not working

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt -d Hydro
-    echo "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_prompt$hydro_color_normal "
+    echo -e "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_prompt$hydro_color_normal "
 end


### PR DESCRIPTION
With 83c6f26a9951cf97af9dc05c214bf04ea04f3780 the multiline prompt got broken.

Normally `echo` will not parse the `\n` used to get the multiline prompt to work. Using `string unescape` should solve this and also keep the intended change of 83c6f26a9951cf97af9dc05c214bf04ea04f3780