### PR TITLE
Ignore git for certaint directories 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Misc
 
-| Variable                     | Type    | Description                                              | Default |
-| ---------------------------- | ------- | -------------------------------------------------------- | ------- |
-| `fish_prompt_pwd_dir_length` | numeric | The number of characters to display when path shortening | 1       |
+| Variable                     | Type    | Description                                                                | Default |
+| ---------------------------- | ------- | -------------------------------------------------------------------------- | ------- |
+| `fish_prompt_pwd_dir_length` | numeric | The number of characters to display when path shortening                   | 1       |
+| `hydro_ignored_git_paths`    | strings | Space separated list of paths where no git information should be displayed | ""      |
 
 
 ## License

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -58,6 +58,10 @@ function _hydro_prompt --on-event fish_prompt
 
     command kill $_hydro_last_pid 2>/dev/null
 
+    set --local git_root (command git rev-parse --show-toplevel 2>/dev/null)
+    if contains $git_root $hydro_ignored_git_paths
+        return
+    end
     fish --private --command "
         ! command git --no-optional-locks rev-parse 2>/dev/null && set $_hydro_git && exit
 


### PR DESCRIPTION
I added a new configuration variable `$hydro_ignored_git_paths` where you can put
paths you do not want hydro to display git information in the prompt.

My use-case is that I have my $HOME in a git repo to manage my dotfiles etc. 

If you like this feature I would make another commit adding the information  in the README.