### PR TITLE
add a visual indicator for Fedora Toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Show current bindings mode.
 <i>R</i> <b>~</b> ❱ ⎢
 </pre>
 
+Show the current [Toolbox] name when operating inside of a [toolbox].
+
+<pre>
+<b style="color:#800080">⬢ devel</b> ~/p/<b>hydro</b> ❱ ⎢
+</pre>
+
 We even set the terminal title to `$PWD` and the currently running command for you.
 
 ```
@@ -100,6 +106,7 @@ Modify variables using `set --universal` from the command line or `set --global`
 | `hydro_symbol_git_dirty`  | string | Dirty repository symbol.        | •       |
 | `hydro_symbol_git_ahead`  | string | Ahead of your upstream symbol.  | ↑       |
 | `hydro_symbol_git_behind` | string | Behind of your upstream symbol. | ↓       |
+| `hydro_symbol_toolbox`    | string | Inside of a toolbox.            | ⬢       |
 
 ### Colors
 
@@ -107,6 +114,7 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 | Variable               | Type  | Description                    | Default              |
 | ---------------------- | ----- | ------------------------------ | -------------------- |
+| `hydro_color_toolbox`  | color | Color of the toolbox segment.  | `800080`             |
 | `hydro_color_pwd`      | color | Color of the pwd segment.      | `$fish_color_normal` |
 | `hydro_color_git`      | color | Color of the git segment.      | `$fish_color_normal` |
 | `hydro_color_error`    | color | Color of the error segment.    | `$fish_color_error`  |
@@ -115,10 +123,11 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Flags
 
-| Variable          | Type    | Description                                  | Default |
-| ----------------- | ------- | -------------------------------------------- | ------- |
-| `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false` |
-| `hydro_multiline` | boolean | Display prompt character on a separate line. | `false` |
+| Variable                       | Type    | Description                                  | Default |
+| ------------------------------ | ------- | -------------------------------------------- | ------- |
+| `hydro_fetch`                  | boolean | Fetch git remote in the background.          | `false` |
+| `hydro_multiline`              | boolean | Display prompt character on a separate line. | `false` |
+| `hydro_toolbox_show_anonymous` | boolean | Do not hide the name of anonymous toolboxes  | `false` |
 
 ### Misc
 
@@ -130,3 +139,6 @@ Modify variables using `set --universal` from the command line or `set --global`
 ## License
 
 [MIT](LICENSE.md)
+
+
+[toolbox]: https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt -d Hydro
-    echo -e "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_prompt$hydro_color_normal "
+    echo -e "$_hydro_color_toolbox$_hydro_toolbox$hydro_color_normal$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_prompt$hydro_color_normal "
 end


### PR DESCRIPTION
Adds a symbol to indicate when the user is currently inside of a [Toolbox](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/). The bash prompt of Fedora Silverblue natively supports Toolbox detection and shows a magenta hexagon at the beginning of the prompt when operating inside of a Toolbox. However, I personally prefer to use fish but cannot find any fish prompt that supports Toolbox. I hope this will be useful to other Silverblue users.

By default, the symbol is a magenta hexagon to align with bash and zsh.

---

It is currently not possible (https://github.com/containers/toolbox/issues/98) to get the toolbox name from environment variables so the name is extracted from `/run/.containerenv` once toolbox is detected