### PR TITLE
add an option to display only the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Flags
 
-| Variable          | Type    | Description                                  | Default |
-| ----------------- | ------- | -------------------------------------------- | ------- |
-| `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false` |
-| `hydro_multiline` | boolean | Display prompt character on a separate line. | `false` |
+| Variable                    | Type    | Description                                  | Default |
+| --------------------------- | ------- | -------------------------------------------- | ------- |
+| `hydro_fetch`               | boolean | Fetch git remote in the background.          | `false` |
+| `hydro_multiline`           | boolean | Display prompt character on a separate line. | `false` |
+| `hydro_pwd_currentdir_only` | boolean | Display only the top-level directory.        | `false` |
 
 ### Misc
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -15,7 +15,12 @@ function _hydro_pwd --on-variable PWD --on-variable hydro_ignored_git_paths
 
     set --query fish_prompt_pwd_dir_length || set --local fish_prompt_pwd_dir_length 1
 
-    if test "$fish_prompt_pwd_dir_length" -le 0 || test "$hydro_multiline" = true
+    if test "$hydro_pwd_currentdir_only" = true
+        test "$PWD" = '/' && set --global _hydro_pwd "\x1b[1m/\x1b[22m" || \
+        set --global _hydro_pwd (
+            string replace --regex -- '^(?:/(?:[^/]+/)*)([^/]+)$' "\x1b[1m\$1\x1b[22m" $PWD
+        )
+    else if test "$fish_prompt_pwd_dir_length" -le 0 || test "$hydro_multiline" = true
         set --global _hydro_pwd (
             string replace --ignore-case -- ~ \~ $PWD |
             string replace --regex -- '([^/]+)$' "\x1b[1m\$1\x1b[22m" |
@@ -137,3 +142,4 @@ set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑
 set --query hydro_symbol_git_behind || set --global hydro_symbol_git_behind ↓
 set --query hydro_multiline || set --global hydro_multiline false
+set --query hydro_pwd_currentdir_only || set --global hydro_pwd_currentdir_only false


### PR DESCRIPTION
I like my prompt to be as short as possible so I've added an option to remove the trailing directories from the prompt to leave only the topmost (current) directory. This means that if you are in `/home/user/projects/foo/bar` it would only display `bar`. Since this would prevent the user to know when they are located in `/` I've added a check for this so that it displays `/` when at the root of the filesystem. This feature is turned off by default but can be enabled by setting `hydro_pwd_currentdir_only` to `true`