### PR TITLE
Introduce add-ons

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -1,8 +1,9 @@
 status is-interactive || exit
 
 set --global _hydro_git _hydro_git_$fish_pid
+set --global _hydro_addons _hydro_items_$fish_pid
 
-function $_hydro_git --on-variable $_hydro_git
+function $_hydro_git --on-variable $_hydro_git --on-variable $_hydro_addons
     commandline --function repaint
 end
 
@@ -65,7 +66,11 @@ function _hydro_prompt --on-event fish_prompt
 
     set --query _hydro_skip_git_prompt && set $_hydro_git && return
 
+    set --local addons _hydro_addon_{$hydro_prompt_addons}\;
+
     fish --private --command "
+        set --universal $_hydro_addons ($addons) \"\"
+
         set branch (
             command git symbolic-ref --short HEAD 2>/dev/null ||
             command git describe --tags --exact-match HEAD 2>/dev/null ||
@@ -102,7 +107,7 @@ function _hydro_prompt --on-event fish_prompt
 end
 
 function _hydro_fish_exit --on-event fish_exit
-    set --erase $_hydro_git
+    set --erase $_hydro_git $_hydro_addons
 end
 
 function _hydro_uninstall --on-event hydro_uninstall

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt --description Hydro
-    echo -e "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
+    echo -e "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$$_hydro_addons$_hydro_status$hydro_color_normal "
 end


### PR DESCRIPTION
Addons let you add new components to your Hydro prompt. They're not as flexible as [Tide items](https://github.com/IlanCosman/tide#extensible) (and don't intend to be). My goal is not to reinvent Tide, but still allow a degree of configuration not possible right now. For example, maybe I'd want to display the current Node version using nvm.

Creating an addon is easy:

```fish
function _hydro_addon_node
    echo (set_color yellow) ⍺ (nvm current)(set_color normal)
end
```
Then in `config.fish`:

```fish
set --global hydro_prompt_addons node
```

![hydro](https://user-images.githubusercontent.com/56996/176985499-cbdf9391-4b8b-42ba-ac1e-827dc93bfd94.png)

Closes #34 #35 #36