### PR TITLE
Make cmd duration threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Display how many commits ahead and/or behind you are of your upstream—prompt r
 ~/p/<b>hydro</b> main ❱ ⎢
 </pre>
 
-Display [`$CMD_DURATION`](https://fishshell.com/docs/current/language.html?highlight=cmd_duration#envvar-CMD_DURATION) when > `1` second.
+Display [`$CMD_DURATION`](https://fishshell.com/docs/current/language.html?highlight=cmd_duration#envvar-CMD_DURATION) when > `1` second. [Configurable](#configuration).
 
 <pre>
 ~/p/<b>hydro</b> main ❱ git push --quiet
@@ -116,10 +116,11 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Misc
 
-| Variable                     | Type    | Description                                                                                                              | Default |
-| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `fish_prompt_pwd_dir_length` | numeric | The number of characters to display when path shortening. Set it to `0` to display only the topmost (current) directory. | `1`     |
-| `hydro_ignored_git_paths`    | strings | Space separated list of paths where no git info should be displayed.                                                     | `""`    |
+| Variable                       | Type    | Description                                                                                                              | Default |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `fish_prompt_pwd_dir_length`   | numeric | The number of characters to display when path shortening. Set it to `0` to display only the topmost (current) directory. | `1`     |
+| `hydro_ignored_git_paths`      | strings | Space separated list of paths where no git info should be displayed.                                                     | `""`    |
+| `hydro_cmd_duration_threshold` | numeric | Minimum command duration, in milliseconds, after which command duration is displayed.                                    | `1000`  |
 
 ## License
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -42,7 +42,7 @@ function _hydro_postexec --on-event fish_postexec
         end
     end
 
-    test "$CMD_DURATION" -lt 1000 && set _hydro_cmd_duration && return
+    test "$CMD_DURATION" -lt $hydro_cmd_duration_threshold && set _hydro_cmd_duration && return
 
     set --local secs (math --scale=1 $CMD_DURATION/1000 % 60)
     set --local mins (math --scale=0 $CMD_DURATION/60000 % 60)
@@ -134,3 +134,4 @@ set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑
 set --query hydro_symbol_git_behind || set --global hydro_symbol_git_behind ↓
 set --query hydro_multiline || set --global hydro_multiline false
+set --query hydro_cmd_duration_threshold || set --global hydro_cmd_duration_threshold 1000


### PR DESCRIPTION
Hi,

this PR indroduces a `hydro_cmd_duration_threshold` setting, to shorten or lengthen the default 1s threshold.

Thank you for hydro, love it!