### PR TITLE
Add dirty count to git dirty indicator

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -75,8 +75,8 @@ function _hydro_prompt --on-event fish_prompt
 
         test -z \"\$$_hydro_git\" && set --universal $_hydro_git \"\$branch \"
 
-        ! command git diff-index --quiet HEAD 2>/dev/null ||
-            count (command git ls-files --others --exclude-standard) >/dev/null && set info \"$hydro_symbol_git_dirty\"
+        command git status --porcelain | count | read dirty_count
+        test \"\$dirty_count\" -gt 0 && set info \"$hydro_symbol_git_dirty\$dirty_count\"
 
         for fetch in $hydro_fetch false
             command git rev-list --count --left-right @{upstream}...@ 2>/dev/null |


### PR DESCRIPTION
If a file is added, deleted or modified, the git dirty status indicator will now show the count.