### PR TITLE
Add git stash indicator with count (when greater than 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Modify variables using `set --universal` from the command line or `set --global`
 | `hydro_symbol_git_dirty`  | string | Dirty repository symbol.        | `•`     |
 | `hydro_symbol_git_ahead`  | string | Ahead of your upstream symbol.  | `↑`     |
 | `hydro_symbol_git_behind` | string | Behind of your upstream symbol. | `↓`     |
+| `hydro_symbol_git_stash`  | string | Stash present symbol.           | `≡`     |
 
 ### Colors
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -78,6 +78,12 @@ function _hydro_prompt --on-event fish_prompt
         ! command git diff-index --quiet HEAD 2>/dev/null ||
             count (command git ls-files --others --exclude-standard) >/dev/null && set info \"$hydro_symbol_git_dirty\"
 
+        command git rev-list --walk-reflogs --count refs/stash 2>/dev/null | read stash_count 
+        if test -n \"\$stash_count\"
+            test \"\$stash_count\" -eq 1 && set stash \" $hydro_symbol_git_stash\"
+            test \"\$stash_count\" -gt 1 && set stash \" $hydro_symbol_git_stash\$stash_count\"
+        end
+
         for fetch in $hydro_fetch false
             command git rev-list --count --left-right @{upstream}...@ 2>/dev/null |
                 read behind ahead
@@ -92,7 +98,7 @@ function _hydro_prompt --on-event fish_prompt
                     set upstream \" $hydro_symbol_git_ahead\$ahead $hydro_symbol_git_behind\$behind\"
             end
 
-            set --universal $_hydro_git \"\$branch\$info\$upstream \"
+            set --universal $_hydro_git \"\$branch\$info\$upstream\$stash \"
 
             test \$fetch = true && command git fetch --no-tags 2>/dev/null
         end
@@ -133,5 +139,6 @@ set --query hydro_symbol_prompt || set --global hydro_symbol_prompt ❱
 set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •
 set --query hydro_symbol_git_ahead || set --global hydro_symbol_git_ahead ↑
 set --query hydro_symbol_git_behind || set --global hydro_symbol_git_behind ↓
+set --query hydro_symbol_git_stash || set --global hydro_symbol_git_stash ≡
 set --query hydro_multiline || set --global hydro_multiline false
 set --query hydro_cmd_duration_threshold || set --global hydro_cmd_duration_threshold 1000


### PR DESCRIPTION
Adds a git stash indicator when a stash is present. If there are more than 1 stashes present, it will also include a count.