### PR TITLE
Prefix variables to add user defined static symbols

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -92,7 +92,7 @@ function _hydro_prompt --on-event fish_prompt
                     set upstream \" $hydro_symbol_git_ahead\$ahead $hydro_symbol_git_behind\$behind\"
             end
 
-            set --universal $_hydro_git \"\$hydro_prefix_git\$branch\$info\$upstream \"
+            set --universal $_hydro_git \"$hydro_prefix_git\$branch\$info\$upstream \"
 
             test \$fetch = true && command git fetch --no-tags 2>/dev/null
         end

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -114,7 +114,7 @@ end
 
 set --global hydro_color_normal (set_color normal)
 
-for color in hydro_color_{pwd,git,error,prompt,duration}
+for color in hydro_color_{pwd,git,error,prompt,duration,beginning}
     function $color --on-variable $color --inherit-variable color
         set --query $color && set --global _$color (set_color $$color)
     end && $color

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -54,7 +54,7 @@ function _hydro_postexec --on-event fish_postexec
     test $mins -gt 0 && set --local --append out $mins"m"
     test $secs -gt 0 && set --local --append out $secs"s"
 
-    set --global _hydro_cmd_duration "$out "
+    set --global _hydro_cmd_duration "$hydro_duration_prefix$out "
 end
 
 function _hydro_prompt --on-event fish_prompt
@@ -92,7 +92,7 @@ function _hydro_prompt --on-event fish_prompt
                     set upstream \" $hydro_symbol_git_ahead\$ahead $hydro_symbol_git_behind\$behind\"
             end
 
-            set --universal $_hydro_git \"\$branch\$info\$upstream \"
+            set --universal $_hydro_git \"\$hydro_git_prefix\$branch\$info\$upstream \"
 
             test \$fetch = true && command git fetch --no-tags 2>/dev/null
         end

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -54,7 +54,7 @@ function _hydro_postexec --on-event fish_postexec
     test $mins -gt 0 && set --local --append out $mins"m"
     test $secs -gt 0 && set --local --append out $secs"s"
 
-    set --global _hydro_cmd_duration "$hydro_duration_prefix$out "
+    set --global _hydro_cmd_duration "$hydro_prefix_duration$out "
 end
 
 function _hydro_prompt --on-event fish_prompt
@@ -92,7 +92,7 @@ function _hydro_prompt --on-event fish_prompt
                     set upstream \" $hydro_symbol_git_ahead\$ahead $hydro_symbol_git_behind\$behind\"
             end
 
-            set --universal $_hydro_git \"\$hydro_git_prefix\$branch\$info\$upstream \"
+            set --universal $_hydro_git \"\$hydro_prefix_git\$branch\$info\$upstream \"
 
             test \$fetch = true && command git fetch --no-tags 2>/dev/null
         end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt --description Hydro
-    echo -e "$hydro_color_normal$hydro_prefix_beginning$_hydro_color_pwd$hydro_prefix_pwd$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
+    echo -e "$_hydro_color_beginning$hydro_prefix_beginning$_hydro_color_pwd$hydro_prefix_pwd$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt --description Hydro
-    echo -e "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
+    echo -e "$hydro_color_normal$hydro_prompt_prefix$_hydro_color_pwd$hydro_pwd_prefix$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt --description Hydro
-    echo -e "$hydro_color_normal$hydro_prompt_prefix$_hydro_color_pwd$hydro_pwd_prefix$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
+    echo -e "$hydro_color_normal$hydro_prefix_beginning$_hydro_color_pwd$hydro_prefix_pwd$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
 end


### PR DESCRIPTION
#51 
Implemented following variables:

**hydro_prefix_beginning
hydro_prefix_git
hydro_prefix_pwd
hydro_prefix_duration**

**hydro_prefix_beginning** can be colored with new introduced color variable: **hydro_color_beginning**

It is possible to add user-defined static text to prepend blocks, like this:

```fish
set --global hydro_multiline true

set --global hydro_color_prompt 94e2d5
set --global hydro_color_error f38ba8
set --global hydro_color_pwd b4befe
set --global hydro_color_git f9e2af
set --global hydro_color_duration 94e2d5
#set --global hydro_color_beginning 94e2d5

set --global hydro_prefix_beginning \n"$os_icon "
set --global hydro_prefix_git " "
set --global hydro_prefix_pwd " "
set --global hydro_prefix_duration "󰅐 "
```

![Screenshot_20240123_235336](https://github.com/jorgebucaran/hydro/assets/20306964/00b8a357-0828-4e8b-bdb4-a00343fcb781)
