### PR TITLE
use $last_pid instead of jobs -lp

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -98,7 +98,7 @@ function _hydro_prompt --on-event fish_prompt
         end
     " &
 
-    set --global _hydro_last_pid (jobs --last --pid)
+    set --global _hydro_last_pid $last_pid
 end
 
 function _hydro_fish_exit --on-event fish_exit


### PR DESCRIPTION
`jobs --last --pid` gives the pid of the most recently started job that is still running (or nothing if none is running), while `$last_pid` will give what one expects regardless.

Try:
```
❱ command true & ; sleep .1 ; echo -e "last_pid: $last_pid\njobs -lp: $(jobs -lp)"
last_pid: 17238
jobs -lp: 
```

This PR does very little difference in practice (the only thing it fixes is that, in the unlikey case one has other running jobs and the even more unlikely case the whole background _fish_ process ends before `jobs --last --pid` is called, hydro may end up terminating an unrelated job), so don't think too much about it if you feel it may introduce other issues.