### PR TITLE
Empty repositories should not have dirty indications

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -75,7 +75,8 @@ function _hydro_prompt --on-event fish_prompt
 
         test -z \"\$$_hydro_git\" && set --universal $_hydro_git \"\$branch \"
 
-        ! command git diff-index --quiet HEAD 2>/dev/null ||
+        command git diff-index --quiet HEAD 2>/dev/null
+        test \$status -eq 1 ||
             count (command git ls-files --others --exclude-standard (command git rev-parse --show-toplevel)) >/dev/null && set info \"$hydro_symbol_git_dirty\"
 
         for fetch in $hydro_fetch false


### PR DESCRIPTION
This PR addresses the issue of dirty status being incorrectly shown in empty repositories.

## Description
Empty repositories shouldn't show dirty status indicators, but they currently do:
```shell
at 11:32:45 ❯ git status
On branch main

No commits yet

nothing to commit (create/copy files and use "git add" to track)

 ~/D/T/empty-git main* # <--------------- this
➜
```

The root cause is that `git diff-index --quiet HEAD 2>/dev/null` returns status code `128` in empty repositories:
```shell
at 11:36:29 ❯ git diff-index --quiet HEAD 2>/dev/null
at 11:36:33 ❯ echo $status
128
```

According to the [diff-index documentation](https://git-scm.com/docs/git-diff-index#Documentation/git-diff-index.txt---quiet):
```
That is, it exits with 1 if there were differences and 0 means no differences.
```
The logic has been modified based on the documentation to specifically check if the status code of `git diff-index --quiet HEAD 2>/dev/null` is 1.

## Performance
Test scripts:
- new.fish:
```fish
#!/usr/local/bin/fish

command git diff-index --quiet HEAD 2>/dev/null;test $status -eq 1 ||
    count (command git ls-files --others --exclude-standard (command git rev-parse --show-toplevel)) >/dev/null &&
    echo new-dirty
```

- old.fish:
```fish
#!/usr/local/bin/fish

! command git diff-index --quiet HEAD 2>/dev/null  ||
    count (command git ls-files --others --exclude-standard (command git rev-parse --show-toplevel)) >/dev/null &&
    echo old-dirty
```

### When There Are No Changes
1. Testing in empty repository (will execute `git ls-files` command because there are no changes)
```shell
at 11:57:04 ❯ git status
On branch main

No commits yet

nothing to commit (create/copy files and use "git add" to track)
at 11:57:07 ❯ time ../../Test/old.fish;echo '-------';time ../../Test/new.fish
old-dirty # <--- Old logic, shows output

________________________________________________________
Executed in   75.64 millis    fish           external
   usr time   35.28 millis   97.00 micros   35.19 millis
   sys time   34.34 millis  595.00 micros   33.74 millis

-------
    # <--- New logic, no output
________________________________________________________
Executed in  130.20 millis    fish           external
   usr time   58.08 millis   97.00 micros   57.98 millis
   sys time   62.54 millis  614.00 micros   61.92 millis
```

2. Testing in non-empty repository (nixpkgs)
```shell
at 11:59:00 ❯ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
at 11:59:02 ❯ time ../../Test/old.fish;echo '-------';time ../../Test/new.fish
    # <--- Old logic, no output
________________________________________________________
Executed in    1.31 secs    fish           external
   usr time    0.73 secs  137.00 micros    0.73 secs
   sys time    2.84 secs  953.00 micros    2.83 secs

-------
    # <--- New logic, no output
________________________________________________________
Executed in    1.31 secs    fish           external
   usr time    0.35 secs   78.00 micros    0.35 secs
   sys time    1.52 secs  701.00 micros    1.52 secs
```

### When There Are Changes
1. Testing in empty repository (adding a file)
```shell
at 12:01:44 ❯ git status
On branch main

No commits yet

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	1

nothing added to commit but untracked files present (use "git add" to track)
at 12:01:47 ❯ time ../../Test/old.fish;echo '-------';time ../../Test/new.fish
old-dirty

________________________________________________________
Executed in   76.60 millis    fish           external
   usr time   35.62 millis   93.00 micros   35.53 millis
   sys time   35.26 millis  634.00 micros   34.63 millis

-------
new-dirty

________________________________________________________
Executed in  130.38 millis    fish           external
   usr time   58.21 millis   90.00 micros   58.12 millis
   sys time   62.64 millis  596.00 micros   62.04 millis
```

2. Committing and modifying file in empty repository
```shell
at 12:02:27 ❯ git status
On branch main

No commits yet

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	1

nothing added to commit but untracked files present (use "git add" to track)
at 12:02:28 ❯ git add .
at 12:02:29 ❯ git commit -v
[main (root-commit) 2102c5c] add 1
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 1
at 12:03:04 ❯ nvim 1
at 12:03:40 ❯ git status
On branch main
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   1

no changes added to commit (use "git add" and/or "git commit -a")
at 12:03:42 ❯ time ../../Test/old.fish;echo '-------';time ../../Test/new.fish
old-dirty

________________________________________________________
Executed in   78.95 millis    fish           external
   usr time   36.34 millis   90.00 micros   36.25 millis
   sys time   36.45 millis  979.00 micros   35.47 millis

-------
new-dirty

________________________________________________________
Executed in   77.09 millis    fish           external
   usr time   36.12 millis   91.00 micros   36.02 millis
   sys time   35.22 millis  933.00 micros   34.28 millis
```

3. Adding new file after commit in empty repository
```shell
at 12:05:10 ❯ touch 2
at 12:05:12 ❯ git status
On branch main
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	2

nothing added to commit but untracked files present (use "git add" to track)
at 12:05:13 ❯ time ../../Test/old.fish;echo '-------';time ../../Test/new.fish
old-dirty

________________________________________________________
Executed in  134.45 millis    fish           external
   usr time   59.48 millis   96.00 micros   59.39 millis
   sys time   65.51 millis  984.00 micros   64.53 millis

-------
new-dirty

________________________________________________________
Executed in  132.88 millis    fish           external
   usr time   59.05 millis    0.11 millis   58.94 millis
   sys time   63.87 millis    1.00 millis   62.86 millis
```

4. Testing in non-empty repository (nixpkgs)
```shell
at 12:01:04 ❯ nvim README.md
at 12:01:10 ❯ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   README.md

no changes added to commit (use "git add" and/or "git commit -a")
at 12:01:13 ❯ time ../../Test/old.fish;echo '-------';time ../../Test/new.fish
old-dirty

________________________________________________________
Executed in  150.21 millis    fish           external
   usr time   95.83 millis   94.00 micros   95.73 millis
   sys time  578.40 millis  873.00 micros  577.52 millis

-------
new-dirty

________________________________________________________
Executed in  147.23 millis    fish           external
   usr time   94.34 millis  112.00 micros   94.23 millis
   sys time  568.58 millis  910.00 micros  567.67 millis
```

Overall, there is no performance degradation with the new implementation.


Translated by AI.