### PR TITLE
Don't source config.fish inside prompt

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -65,7 +65,7 @@ function _hydro_prompt --on-event fish_prompt
 
     set --query _hydro_skip_git_prompt && set $_hydro_git && return
 
-    fish --private --command "
+    fish --no-config --private --command "
         set branch (
             command git symbolic-ref --short HEAD 2>/dev/null ||
             command git describe --tags --exact-match HEAD 2>/dev/null ||


### PR DESCRIPTION
Uses the hint mentioned in #42, but in the long form to be consistent with the other switches.

Closes #42 