### PR TITLE
Add support for shortening git branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Modify variables using `set --universal` from the command line or `set --global`
 | Variable                       | Type    | Description                                                                                                              | Default |
 | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
 | `fish_prompt_pwd_dir_length`   | numeric | The number of characters to display when path shortening. Set it to `0` to display only the topmost (current) directory. | `1`     |
+| `fish_prompt_git_prefix_length`| numeric | The number of characters to trim from the beginning of the branch name.                                                  | `0`     |
+| `fish_prompt_git_infix_length` | numeric | The number of characters to display beginning from `fish_prompt_git_prefix_length` of the branch name.                   |         |
+| `fish_prompt_git_suffix_length`| numeric | The number of characters to display from the end of the branch name.                                                     | `0`     |
 | `hydro_ignored_git_paths`      | strings | Space separated list of paths where no git info should be displayed.                                                     | `""`    |
 | `hydro_cmd_duration_threshold` | numeric | Minimum command duration, in milliseconds, after which command duration is displayed.                                    | `1000`  |
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -73,6 +73,10 @@ function _hydro_prompt --on-event fish_prompt
                 string replace --regex -- '(.+)' '@\$1'
         )
 
+        if test -z \$fish_prompt_git_infix_length
+            set branch (string replace --regex -- '.{$fish_prompt_git_prefix_length}(.{$fish_prompt_git_infix_length}).*(.{$fish_prompt_git_suffix_length})' '\$1...\$2' \$branch)
+        end
+
         test -z \"\$$_hydro_git\" && set --universal $_hydro_git \"\$branch \"
 
         command git diff-index --quiet HEAD 2>/dev/null
@@ -129,6 +133,8 @@ function hydro_multiline --on-variable hydro_multiline
     end
 end && hydro_multiline
 
+set --query fish_prompt_git_prefix_length || set fish_prompt_git_prefix_length 0
+set --query fish_prompt_git_suffix_length || set fish_prompt_git_suffix_length 0
 set --query hydro_color_error || set --global hydro_color_error $fish_color_error
 set --query hydro_symbol_prompt || set --global hydro_symbol_prompt ❱
 set --query hydro_symbol_git_dirty || set --global hydro_symbol_git_dirty •


### PR DESCRIPTION
Adds support for shortening git branch name.
E.g. branch name is `feature/TEAM-1111-some-really-long-name-abcd`
Setting only `fish_prompt_git_infix_length` to `9` will enable this feature and give `feature/T...`
And setting `fish_prompt_git_prefix_length` to `8` will give `TEAM-1111...`
And setting `fish_prompt_git_suffix_length` to `4` will give `TEAM-1111...abcd`