### PR TITLE
Add a username/hostname section to the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,21 +100,23 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 > Any argument accepted by [`set_color`](https://fishshell.com/docs/current/cmds/set_color.html).
 
-| Variable               | Type  | Description                    | Default              |
-| ---------------------- | ----- | ------------------------------ | -------------------- |
-| `hydro_color_pwd`      | color | Color of the pwd segment.      | `$fish_color_normal` |
-| `hydro_color_git`      | color | Color of the git segment.      | `$fish_color_normal` |
-| `hydro_color_start`    | color | Color of the start symbol.     | `$fish_color_normal` |
-| `hydro_color_error`    | color | Color of the error segment.    | `$fish_color_error`  |
-| `hydro_color_prompt`   | color | Color of the prompt symbol.    | `$fish_color_normal` |
-| `hydro_color_duration` | color | Color of the duration section. | `$fish_color_normal` |
+| Variable               | Type  | Description                             | Default              |
+| ---------------------- | ----- | --------------------------------------- | -------------------- |
+| `hydro_color_pwd`      | color | Color of the pwd segment.               | `$fish_color_normal` |
+| `hydro_color_git`      | color | Color of the git segment.               | `$fish_color_normal` |
+| `hydro_color_start`    | color | Color of the start symbol.              | `$fish_color_normal` |
+| `hydro_color_error`    | color | Color of the error segment.             | `$fish_color_error`  |
+| `hydro_color_prompt`   | color | Color of the prompt symbol.             | `$fish_color_normal` |
+| `hydro_color_duration` | color | Color of the duration section.          | `$fish_color_normal` |
+| `hydro_color_who     ` | color | Color of the username/hostname section. | `$fish_color_normal` |
 
 ### Flags
 
-| Variable          | Type    | Description                                  | Default |
-| ----------------- | ------- | -------------------------------------------- | ------- |
-| `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false` |
-| `hydro_multiline` | boolean | Display prompt character on a separate line. | `false` |
+| Variable                 | Type    | Description                                  | Default |
+| ------------------------ | ------- | -------------------------------------------- | ------- |
+| `hydro_fetch`            | boolean | Fetch git remote in the background.          | `false` |
+| `hydro_multiline`        | boolean | Display prompt character on a separate line. | `false` |
+| `hydro_always_show_user` | boolean | Always display username.                     | `false` |
 
 ### Misc
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -31,6 +31,37 @@ function _hydro_pwd --on-variable PWD --on-variable hydro_ignored_git_paths --on
     )
 end
 
+function _hydro_who
+    set --local show_hostname false
+    if set --query SSH_CONNECTION
+        set --local show_hostname true
+    else
+        switch (uname)
+        case Linux
+            if test -f /proc/1/environ && grep -qa container=lxc /proc/1/environ
+                set --local show_hostname true
+            end
+        case FreeBSD
+            if test "$(sysctl -n security.jail.jailed)" = "1"
+                set --local show_hostname true
+            end
+        case SunOS
+            if test "$(zonename)" != "global"
+                set --local show_hostname true
+            end
+        end
+    end
+
+    if test "$show_hostname" = true
+        set --local host (
+            string split --fields 1 . "@$hostname"
+        )
+        set --global _hydro_who "$USER$host "
+    else if test "$hydro_always_show_user" = true
+        set --global _hydro_who "$USER "
+    end
+end
+
 function _hydro_postexec --on-event fish_postexec
     set --local last_status $pipestatus
     set --global _hydro_status "$_hydro_newline$_hydro_color_prompt$hydro_symbol_prompt"
@@ -60,6 +91,7 @@ end
 function _hydro_prompt --on-event fish_prompt
     set --query _hydro_status || set --global _hydro_status "$_hydro_newline$_hydro_color_prompt$hydro_symbol_prompt"
     set --query _hydro_pwd || _hydro_pwd
+    set --query _hydro_who || _hydro_who
 
     command kill $_hydro_last_pid 2>/dev/null
 
@@ -115,7 +147,7 @@ end
 
 set --global hydro_color_normal (set_color normal)
 
-for color in hydro_color_{pwd,git,error,prompt,duration,start}
+for color in hydro_color_{pwd,git,error,prompt,duration,start,who}
     function $color --on-variable $color --inherit-variable color
         set --query $color && set --global _$color (set_color $$color)
     end && $color

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -59,6 +59,8 @@ function _hydro_who
         set --global _hydro_who "$USER$host "
     else if test "$hydro_always_show_user" = true
         set --global _hydro_who "$USER "
+    else
+        set --global _hydro_who ""
     end
 end
 

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -34,20 +34,20 @@ end
 function _hydro_who
     set --local show_hostname false
     if set --query SSH_CONNECTION
-        set --local show_hostname true
+        set show_hostname true
     else
         switch (uname)
         case Linux
             if test -f /proc/1/environ && grep -qa container=lxc /proc/1/environ
-                set --local show_hostname true
+                set show_hostname true
             end
         case FreeBSD
             if test "$(sysctl -n security.jail.jailed)" = "1"
-                set --local show_hostname true
+                set show_hostname true
             end
         case SunOS
             if test "$(zonename)" != "global"
-                set --local show_hostname true
+                set show_hostname true
             end
         end
     end

--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -53,10 +53,10 @@ function _hydro_who
     end
 
     if test "$show_hostname" = true
-        set --local host (
-            string split --fields 1 . "@$hostname"
+        set --local short_host (
+            string split --fields 1 . $hostname
         )
-        set --global _hydro_who "$USER$host "
+        set --global _hydro_who "$USER@$short_host "
     else if test "$hydro_always_show_user" = true
         set --global _hydro_who "$USER "
     else

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,3 @@
 function fish_prompt --description Hydro
-    echo -e "$_hydro_color_start$hydro_symbol_start$hydro_color_normal$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
+    echo -e "$_hydro_color_start$hydro_symbol_start$hydro_color_normal$_hydro_color_who$_hydro_who$hydro_color_normal$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
 end


### PR DESCRIPTION
When connecting to remote hosts via ssh or when entering containers (Linux LXC, FreeBSD jails, Solaris zones) it is nice to see where you are working now. Therefore I've added a username/hostname section to the beginning of the prompt.

It always show username@hostname for remote/container prompts. You can set activate hydro_always_show_user to always show the username. Useful when using su to change user on local machines.

Fix for #50 