### PR TITLE
Fix CJK branch name truncation in status

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -67,7 +67,7 @@ function _hydro_prompt --on-event fish_prompt
 
     fish --private --command "
         set branch (
-            command git symbolic-ref --short HEAD 2>/dev/null ||
+            command git branch --show-current 2>/dev/null ||
             command git describe --tags --exact-match HEAD 2>/dev/null ||
             command git rev-parse --short HEAD 2>/dev/null |
                 string replace --regex -- '(.+)' '@\$1'


### PR DESCRIPTION
usage of `git symbolic-ref --short HEAD` was truncating CJK characters in wrong place causing tofu characters, e.g `feat/개�`