### PR TITLE
Fix path corruption when directory name contains a colon

### DIFF
--- a/conf.d/hydro.fish
+++ b/conf.d/hydro.fish
@@ -21,11 +21,11 @@ function _hydro_pwd --on-variable PWD --on-variable hydro_ignored_git_paths --on
 
     set --global _hydro_pwd (
         string replace --ignore-case -- ~ \~ $PWD |
-        string replace -- "/$git_base/" /:/ |
+        string replace -- "/$git_base/" /\x1e/ |
         string replace --regex --all -- "(\.?[^/]{"(
             string replace --regex --all -- '^$' 1 "$fish_prompt_pwd_dir_length"
         )"})[^/]*/" "\$1$path_sep" |
-        string replace -- : "$git_base" |
+        string replace -- \x1e "$git_base" |
         string replace --regex -- '([^/]+)$' "\x1b[1m\$1\x1b[22m" |
         string replace --regex --all -- '(?!^/$)/|^$' "\x1b[2m/\x1b[22m"
     )


### PR DESCRIPTION
## Problem

When the current directory name contains a colon (when using git worktrees, e.g. `repo:branch-name`), the prompt duplicates parts of the path.

For example, inside a directory named `core-backend:fix-something`:

```
Expected: ~/Projects/core-backend:fix-something
Actual:   ~/Projects/core-backendcore-backend:fix-somethingfix-something
```

## Cause

`_hydro_pwd` uses `:` as a temporary sentinel when abbreviating the git root in the displayed path (lines 24 and 28 of `conf.d/hydro.fish`):

1. Line 24 replaces `/$git_base/` with `:/` — using `:` as a placeholder
2. Line 28 replaces `:` back with `$git_base`

When the directory name already contains a literal colon, step 2 matches it instead of the sentinel, replacing it with `$git_base` and corrupting the output.

## Fix

Replace the `:` sentinel with `\x1e` (ASCII Record Separator), a non-printable character that cannot appear in filesystem paths.