### PR TITLE
feat: support transient prompt via --final-rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ Display the current bindings mode.
 <i>R</i> <b>~</b> ❱ ⎢
 </pre>
 
+Support for [transient prompt](https://fishshell.com/docs/current/prompt.html#transient-prompt) (fish 4.0+). Declutters scrollback by replacing executed prompts with a minimal version.
+
+<pre>
+❱ git commit -am Hotfix
+❱ git pull --rebase && git push
+~/p/<b>hydro</b> main ❱ ⎢
+</pre>
+
+> Enable with `set -g fish_transient_prompt 1`. Customize the style with [`hydro_transient`](#configuration).
+
+| `hydro_transient` | Scrollback appearance |
+| ----------------- | --------------------- |
+| `prompt` (default)| `❱ command`           |
+| `basename`        | `hydro ❱ command`     |
+| `pwd`             | `~/p/hydro ❱ command` |
+
 ## Performance
 
 Blazing fast would be an understatement considering that the [LLVM repo](https://github.com/llvm/llvm-project) has over 375,000 commits!
@@ -111,10 +127,11 @@ Modify variables using `set --universal` from the command line or `set --global`
 
 ### Flags
 
-| Variable          | Type    | Description                                  | Default |
-| ----------------- | ------- | -------------------------------------------- | ------- |
-| `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false` |
-| `hydro_multiline` | boolean | Display prompt character on a separate line. | `false` |
+| Variable          | Type    | Description                                  | Default  |
+| ----------------- | ------- | -------------------------------------------- | -------- |
+| `hydro_fetch`     | boolean | Fetch git remote in the background.          | `false`  |
+| `hydro_multiline` | boolean | Display prompt character on a separate line. | `false`  |
+| `hydro_transient` | string  | Transient prompt style: `prompt`, `basename`, or `pwd`. | `prompt` |
 
 ### Misc
 

--- a/functions/fish_mode_prompt.fish
+++ b/functions/fish_mode_prompt.fish
@@ -1,4 +1,5 @@
 function fish_mode_prompt
+    contains -- --final-rendering $argv && return
     if test "$fish_key_bindings" != fish_default_key_bindings
         set --local vi_mode_color
         set --local vi_mode_symbol

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,3 +1,14 @@
 function fish_prompt --description Hydro
+    if contains -- --final-rendering $argv
+        set -l prefix
+        switch $hydro_transient
+            case basename
+                set prefix "$_hydro_color_pwd"(string replace --regex --all -- '.*/' '' $PWD)"$hydro_color_normal "
+            case pwd
+                set prefix "$_hydro_color_pwd$_hydro_pwd$hydro_color_normal "
+        end
+        echo -e -n "$prefix$_hydro_color_prompt$hydro_symbol_prompt$hydro_color_normal "
+        return
+    end
     echo -e -n "$_hydro_color_start$hydro_symbol_start$hydro_color_normal$_hydro_color_pwd$_hydro_pwd$hydro_color_normal $_hydro_color_git$$_hydro_git$hydro_color_normal$_hydro_color_duration$_hydro_cmd_duration$hydro_color_normal$_hydro_status$hydro_color_normal "
 end


### PR DESCRIPTION
Add a transient prompt that listens to fish's `fish_transient_prompt` variable.

<img width="400" height="95" alt="Transient Prompt for hydro" src="https://github.com/user-attachments/assets/4cb3d3d4-2ede-4802-92ba-d8101be33915" />

Further configurable to show more or less information in the transient prompt, configurable via `hydro_transient`:

| `hydro_transient` | Scrollback appearance |
| ----------------- | --------------------- |
| `prompt` (default)| `❱ command`           |
| `basename`        | `hydro ❱ command`     |
| `pwd`             | `~/p/hydro ❱ command` |
